### PR TITLE
Move out hash methods to traits, add `hash_bytes` method.

### DIFF
--- a/benches/bn254_x5_3.rs
+++ b/benches/bn254_x5_3.rs
@@ -3,11 +3,11 @@ use ark_ff::PrimeField;
 use criterion::{criterion_group, criterion_main, Criterion};
 use rand::Rng;
 
-use light_poseidon::{parameters::bn254_x5_3, PoseidonHasher};
+use light_poseidon::{parameters::bn254_x5_3, Poseidon};
 
 pub fn bench_poseidon_bn254_x5_3(c: &mut Criterion) {
     let params = bn254_x5_3::poseidon_parameters();
-    let mut poseidon = PoseidonHasher::new(params);
+    let mut poseidon = Poseidon::new(params);
 
     let random_bytes1 = rand::thread_rng().gen::<[u8; 32]>();
     let random_bytes2 = rand::thread_rng().gen::<[u8; 32]>();


### PR DESCRIPTION
This change refactors the currently existing implementation by:

* Renaming the **struct** from `PoseidonHasher` to `Poseidon`.
* Adding the **trait** called `PoseidonHasher` which provides the `hash` method and is implemented by `Poseidon`.

On top of that, this change adds the `PoseidonBytesHasher` trait with `hash_bytes`. This is convenient for smart contracts / programs which just need the byte result without worrying about Arkworks types.

Signed-off-by: Michal Rostecki <vadorovsky@gmail.com>