### PR TITLE
Ensure that README.md content matches the rustdoc

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -69,3 +69,9 @@ jobs:
         with:
           command: clippy
           args: -- -D warnings
+
+      - name: Check README
+        uses: actions-rs/cargo@v1
+        with:
+          command: xtask
+          args: generate-readme --check

--- a/README.md
+++ b/README.md
@@ -17,10 +17,8 @@ Parameters provided by the library are:
 * x^5 S-boxes
 * t = 2 - 17 (for 1 to 15 inputs)
 * 8 full rounds and partial rounds depending on t [56, 57, 56, 60, 60, 63, 64, 63, 60, 66, 60, 65, 70, 60, 64]
-
 The parameters can be generated with:
 ```$ cargo xtask generate-poseidon-parameters``
-
 ## Output type
 
 [`Poseidon`](crate::Poseidon) type implements two traits which serve the purpose
@@ -43,7 +41,7 @@ and BN254-based parameters provided by the library, with
 result:
 
 ```rust
-use light_poseidon::{Poseidon, PoseidonBytesHasher, parameters::bn254_x5_3::poseidon_parameters};
+use light_poseidon::{Poseidon, PoseidonBytesHasher, parameters::bn254_x5};
 use ark_bn254::Fr;
 use ark_ff::{BigInteger, PrimeField};
 
@@ -67,7 +65,7 @@ use light_poseidon::{Poseidon, PoseidonHasher, parameters::bn254_x5};
 use ark_bn254::Fr;
 use ark_ff::{BigInteger, PrimeField};
 
-let mut poseidon = Poseidon::<Fr>::new_circom(2);
+let mut poseidon = Poseidon::<Fr>::new_circom(2).unwrap();
 
 let input1 = Fr::from_be_bytes_mod_order(&[1u8; 32]);
 let input2 = Fr::from_be_bytes_mod_order(&[2u8; 32]);

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -6,5 +6,6 @@ edition = "2021"
 
 [dependencies]
 anyhow = "1.0"
+cargo-readme = "3.2"
 clap = { version = "4", features = ["derive"] }
 hex = "0.4.3"

--- a/xtask/src/generate_readme.rs
+++ b/xtask/src/generate_readme.rs
@@ -1,0 +1,38 @@
+use std::{env::current_dir, fs::File};
+
+use clap::Parser;
+
+#[derive(Debug, Parser)]
+pub struct Options {
+    /// Do not overwrite the README.md file, just check whether it is up to date.
+    #[clap(long, default_value_t = false)]
+    check: bool,
+}
+
+pub fn generate_readme(opts: Options) -> anyhow::Result<()> {
+    let project_root = current_dir()?.join("light-poseidon");
+    let mut source = File::open("light-poseidon/src/lib.rs")?;
+    let mut template = File::open("README.tpl")?;
+
+    let content = cargo_readme::generate_readme(
+        project_root.as_path(),
+        &mut source,
+        Some(&mut template),
+        true,
+        true,
+        true,
+        true,
+    )
+    .map_err(|e| anyhow::anyhow!(e))?;
+
+    if opts.check {
+        let readme = std::fs::read_to_string("README.md")?;
+        if readme != content {
+            anyhow::bail!("README.md is not up to date");
+        }
+    } else {
+        std::fs::write("README.md", content)?;
+    }
+
+    Ok(())
+}

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -1,6 +1,7 @@
 use clap::Parser;
 
 mod generate_parameters;
+mod generate_readme;
 
 #[derive(Parser)]
 pub struct XtaskOptions {
@@ -11,6 +12,8 @@ pub struct XtaskOptions {
 #[derive(Parser)]
 enum Command {
     GeneratePoseidonParameters(generate_parameters::Options),
+    /// Generate the README.md file.
+    GenerateReadme(generate_readme::Options),
 }
 
 fn main() -> Result<(), anyhow::Error> {
@@ -20,6 +23,7 @@ fn main() -> Result<(), anyhow::Error> {
         Command::GeneratePoseidonParameters(opts) => {
             generate_parameters::generate_parameters(opts)?
         }
+        Command::GenerateReadme(opts) => generate_readme::generate_readme(opts)?,
     }
 
     Ok(())


### PR DESCRIPTION
Add an xtask subcommand which autogenerates README.md from the rustdoc (from `src/lib.rs`) with a `--check` option, used in Github Actions as a part of a lint check.