### PR TITLE
Don't pad the inputs automatically

### DIFF
--- a/light-poseidon/src/lib.rs
+++ b/light-poseidon/src/lib.rs
@@ -314,7 +314,7 @@ impl<F: PrimeField> Poseidon<F> {
 
 impl<F: PrimeField> PoseidonHasher<F> for Poseidon<F> {
     fn hash(&mut self, inputs: &[F]) -> Result<F, PoseidonError> {
-        if inputs.len() > self.params.width - 1 {
+        if inputs.len() != self.params.width - 1 {
             return Err(PoseidonError::InvalidNumberOfInputs {
                 inputs: inputs.len(),
                 max_limit: self.params.width - 1,
@@ -326,9 +326,6 @@ impl<F: PrimeField> PoseidonHasher<F> for Poseidon<F> {
 
         for input in inputs {
             self.state.push(*input);
-        }
-        while self.state.len() < self.params.width {
-            self.state.push(F::zero());
         }
 
         let all_rounds = self.params.full_rounds + self.params.partial_rounds;


### PR DESCRIPTION
Previously when the number of inputs was lower than width - 1, we were filling up the state of hasher with zeros up to the width, which is one of the recommended methods of padding described in section 4.2 of Poseidon hash paper[0].

However, doing so inside the library without user's interference is not the best thing to do and might lead to misusing the API. Users might not be aware of the fact they provided less inputs and then might take the unexpected result for granted.

Also, there are different padding strategies.

The solution to make it more safe here is requiring users to pad the inputs explicitly according to their needs

To make the use of Rust type system, we are switching from storing parameters like width, alpha and round numbers in the `PoseidonParameters` struct to providing them as const generics. That way we can enforce the particular input size on compile time, without having to handle or return custom errors on runtime.

[0] https://eprint.iacr.org/2019/458.pdf

Fixes: #17