### PR TITLE
ci: Add action-semantic-pull-request for linting pull requests

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -1,0 +1,28 @@
+name: "Lint PR"
+
+on:
+  pull_request:
+    branch:
+      - main
+    types:
+      - opened
+      - edited
+      - synchronize
+
+permissions:
+  pull-requests: read
+
+jobs:
+  main:
+    name: Validate PR title
+    runs-on: ubuntu-latest
+    steps:
+      - uses: amannn/action-semantic-pull-request@v5
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          scopes: |
+            core
+            params
+            bench
+            xtask


### PR DESCRIPTION
For this repository, configure it with following scopes:

* `core` - changes related to the library.
* `params` - changes related to the Poseidon parameters / setup.
* `bench` - changes related to our benchmarks.
* `xtask` - changes related to xtask jobs (e.g. generating parameters).