### PR TITLE
fix: Validate byte inputs before changing endianness

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -33,7 +33,6 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: test
-          args: --features fuzz-tests
 
       - name: Run cargo fmt
         uses: actions-rs/cargo@v1

--- a/light-poseidon/Cargo.toml
+++ b/light-poseidon/Cargo.toml
@@ -19,10 +19,6 @@ criterion = "0.5"
 rand = "0.8"
 hex = "0.4.3"
 
-[features]
-fuzz-tests = []
-
-
 [[bench]]
 name = "bn254_x5"
 harness = false

--- a/light-poseidon/tests/bn254_fq_x5.rs
+++ b/light-poseidon/tests/bn254_fq_x5.rs
@@ -1,7 +1,8 @@
 use ark_bn254::Fr;
-use ark_ff::{BigInteger, One, PrimeField, Zero};
+use ark_ff::{BigInteger, BigInteger256, One, PrimeField, Zero};
 use light_poseidon::{Poseidon, PoseidonError};
 use light_poseidon::{PoseidonBytesHasher, PoseidonHasher};
+use rand::Rng;
 
 #[test]
 fn test_poseidon_one() {
@@ -148,18 +149,48 @@ fn test_poseidon_bn254_x5_fq_hash_bytes_le() {
     );
 }
 
-#[cfg(feature = "fuzz-tests")]
-mod fuzz_tests {
-    use ark_ff::BigInteger256;
-    use rand::Rng;
+macro_rules! test_random_input_same_results {
+    ($name:ident, $method:ident) => {
+        #[test]
+        fn $name() {
+            let input = [1u8; 32];
 
-    use super::*;
+            for nr_inputs in 1..12 {
+                let mut hasher = Poseidon::<Fr>::new_circom(nr_inputs).unwrap();
 
-    macro_rules! test_random_input_same_results {
-        ($name:ident, $method:ident) => {
-            #[test]
-            fn $name() {
-                let input = [1u8; 32];
+                let mut inputs = Vec::with_capacity(nr_inputs);
+                for _ in 0..nr_inputs {
+                    inputs.push(input.as_slice());
+                }
+
+                let hash1 = hasher.$method(inputs.as_slice()).unwrap();
+                let hash2 = hasher.$method(inputs.as_slice()).unwrap();
+
+                assert_eq!(hash1, hash2);
+            }
+        }
+    };
+}
+
+test_random_input_same_results!(
+    test_poseidon_bn254_x5_fq_hash_bytes_be_random_input_same_results,
+    hash_bytes_be
+);
+
+test_random_input_same_results!(
+    test_poseidon_bn254_x5_fq_hash_bytes_le_random_input_same_results,
+    hash_bytes_le
+);
+
+macro_rules! test_invalid_input_length {
+    ($name:ident, $method:ident) => {
+        #[test]
+        fn $name() {
+            let mut rng = rand::thread_rng();
+
+            for _ in 0..100 {
+                let len = rng.gen_range(33..524_288_000); // Maximum 500 MB.
+                let input = vec![1u8; len];
 
                 for nr_inputs in 1..12 {
                     let mut hasher = Poseidon::<Fr>::new_circom(nr_inputs).unwrap();
@@ -169,106 +200,68 @@ mod fuzz_tests {
                         inputs.push(input.as_slice());
                     }
 
-                    let hash1 = hasher.$method(inputs.as_slice()).unwrap();
-                    let hash2 = hasher.$method(inputs.as_slice()).unwrap();
-
-                    assert_eq!(hash1, hash2);
-                }
-            }
-        };
-    }
-
-    test_random_input_same_results!(
-        test_poseidon_bn254_x5_fq_hash_bytes_be_random_input_same_results,
-        hash_bytes_be
-    );
-
-    test_random_input_same_results!(
-        test_poseidon_bn254_x5_fq_hash_bytes_le_random_input_same_results,
-        hash_bytes_le
-    );
-
-    macro_rules! test_invalid_input_length {
-        ($name:ident, $method:ident) => {
-            #[test]
-            fn $name() {
-                let mut rng = rand::thread_rng();
-
-                for _ in 0..100 {
-                    let len = rng.gen_range(33..524_288_000); // Maximum 500 MB.
-                    let input = vec![1u8; len];
-
-                    for nr_inputs in 1..12 {
-                        let mut hasher = Poseidon::<Fr>::new_circom(nr_inputs).unwrap();
-
-                        let mut inputs = Vec::with_capacity(nr_inputs);
-                        for _ in 0..nr_inputs {
-                            inputs.push(input.as_slice());
-                        }
-
-                        let hash = hasher.$method(inputs.as_slice());
-                        assert_eq!(
-                            hash,
-                            Err(PoseidonError::InvalidInputLength {
-                                len,
-                                modulus_bytes_len: 32,
-                            })
-                        );
-                    }
-                }
-            }
-        };
-    }
-
-    test_invalid_input_length!(
-        test_poseidon_bn254_x5_fq_hash_bytes_be_invalid_input_length,
-        hash_bytes_be
-    );
-
-    test_invalid_input_length!(
-        test_poseidon_bn254_x5_fq_hash_bytes_le_invalid_input_length,
-        hash_bytes_le
-    );
-
-    macro_rules! test_input_gt_field_size {
-        ($name:ident, $method:ident, $to_bytes_method:ident) => {
-            #[test]
-            fn $name() {
-                let mut greater_than_field_size = Fr::MODULUS;
-                let mut rng = rand::thread_rng();
-                let random_number = rng.gen_range(1u64..1_000_000u64);
-                greater_than_field_size.add_with_carry(&BigInteger256::from(random_number));
-                let greater_than_field_size = greater_than_field_size.$to_bytes_method();
-
-                assert_eq!(greater_than_field_size.len(), 32);
-
-                for nr_inputs in 1..12 {
-                    let mut hasher = Poseidon::<Fr>::new_circom(nr_inputs).unwrap();
-
-                    let mut inputs = Vec::with_capacity(nr_inputs);
-                    for _ in 0..nr_inputs {
-                        inputs.push(&greater_than_field_size[..]);
-                    }
-
                     let hash = hasher.$method(inputs.as_slice());
-                    assert_eq!(hash, Err(PoseidonError::InputLargerThanModulus));
+                    assert_eq!(
+                        hash,
+                        Err(PoseidonError::InvalidInputLength {
+                            len,
+                            modulus_bytes_len: 32,
+                        })
+                    );
                 }
             }
-        };
-    }
-
-    test_input_gt_field_size!(
-        test_poseidon_bn254_fq_hash_bytes_be_input_gt_field_size,
-        hash_bytes_be,
-        to_bytes_be
-    );
-
-    test_input_gt_field_size!(
-        test_poseidon_bn254_fq_hash_bytes_le_input_gt_field_size,
-        hash_bytes_le,
-        to_bytes_le
-    );
+        }
+    };
 }
+
+test_invalid_input_length!(
+    test_poseidon_bn254_x5_fq_hash_bytes_be_invalid_input_length,
+    hash_bytes_be
+);
+
+test_invalid_input_length!(
+    test_poseidon_bn254_x5_fq_hash_bytes_le_invalid_input_length,
+    hash_bytes_le
+);
+
+macro_rules! test_fuzz_input_gt_field_size {
+    ($name:ident, $method:ident, $to_bytes_method:ident) => {
+        #[test]
+        fn $name() {
+            let mut greater_than_field_size = Fr::MODULUS;
+            let mut rng = rand::thread_rng();
+            let random_number = rng.gen_range(1u64..1_000_000u64);
+            greater_than_field_size.add_with_carry(&BigInteger256::from(random_number));
+            let greater_than_field_size = greater_than_field_size.$to_bytes_method();
+
+            assert_eq!(greater_than_field_size.len(), 32);
+
+            for nr_inputs in 1..12 {
+                let mut hasher = Poseidon::<Fr>::new_circom(nr_inputs).unwrap();
+
+                let mut inputs = Vec::with_capacity(nr_inputs);
+                for _ in 0..nr_inputs {
+                    inputs.push(&greater_than_field_size[..]);
+                }
+
+                let hash = hasher.$method(inputs.as_slice());
+                assert_eq!(hash, Err(PoseidonError::InputLargerThanModulus));
+            }
+        }
+    };
+}
+
+test_fuzz_input_gt_field_size!(
+    test_fuzz_poseidon_bn254_fq_hash_bytes_be_input_gt_field_size,
+    hash_bytes_be,
+    to_bytes_be
+);
+
+test_fuzz_input_gt_field_size!(
+    test_fuzz_poseidon_bn254_fq_hash_bytes_le_input_gt_field_size,
+    hash_bytes_le,
+    to_bytes_le
+);
 
 macro_rules! test_input_gt_field_size {
     ($name:ident, $method:ident, $greater_than_field_size:expr) => {


### PR DESCRIPTION
Submitting too large inputs might be a potential DDoS attack vector. Before this change, `hash_bytes_be` was reversing all input byte slices before validating them (to convert them from big-endian to little-endian), so it was prone to an attack, where a malicious user could submit arrays just to DDoS the software using light-poseidon with heavy reversal operations.

Fix that by performing validation as the first operation on byte inputs.

Also, remove the `fuzz-tests` flag and run all tests by default. After this fix, the runtime of fuzz tests is fast. Its degradation is actually an indicator of performance issues or DDoS attack vectors.

Kudos to @samkim-crypto for finding the issue.

Ref: solana-labs/solana#33363