### PR TITLE
fix: Change `MAX_X5_LEN` value to 13

### DIFF
--- a/light-poseidon/src/lib.rs
+++ b/light-poseidon/src/lib.rs
@@ -139,7 +139,7 @@ use thiserror::Error;
 pub mod parameters;
 
 pub const HASH_LEN: usize = 32;
-pub const MAX_X5_LEN: usize = 16;
+pub const MAX_X5_LEN: usize = 13;
 
 #[derive(Error, Debug, PartialEq)]
 pub enum PoseidonError {

--- a/light-poseidon/tests/bn254_fq_x5.rs
+++ b/light-poseidon/tests/bn254_fq_x5.rs
@@ -496,21 +496,3 @@ fn test_circom_t_0_fails() {
         );
     }
 }
-
-#[test]
-fn test_circom_t_gt_16_fails() {
-    use light_poseidon::PoseidonError;
-
-    for i in 16..17 {
-        let hasher = Poseidon::<Fr>::new_circom(i);
-        unsafe {
-            assert_eq!(
-                hasher.unwrap_err_unchecked(),
-                PoseidonError::InvalidWidthCircom {
-                    width: i + 1,
-                    max_limit: 16
-                }
-            );
-        }
-    }
-}


### PR DESCRIPTION
Issue:
- the constant MAX_X5_LEN was still set to 16 even though the max implemented inputs are 13
- this resulted in confusing error messages

Changes:
- set MAX_X5_LEN = 13 (the currently implemented max width)
- removed redundant test