### PR TITLE
fix: Enforce byte input length for the given prime field

### DIFF
--- a/light-poseidon/src/lib.rs
+++ b/light-poseidon/src/lib.rs
@@ -459,7 +459,7 @@ where
     if input.is_empty() {
         return Err(PoseidonError::EmptyInput);
     }
-    if input.len() > modulus_bytes_len {
+    if input.len() != modulus_bytes_len {
         return Err(PoseidonError::InvalidInputLength {
             len: input.len(),
             modulus_bytes_len,


### PR DESCRIPTION
Before this change, we were enforcing only the upper limit of the byte input lenghts in `hash_bytes_be` and `hash_bytes_le` methods. The limit is indicated by the amount of bytes needed to represent the modulus of the given prime field. For the `Fr` field, the limit is 32 bytes.

At the same time, we were allowing smaller byte slices. For example, we were allowing either a full 32-byte array with explicit padding:

```
[
    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
    0, 0, 0, 0, 0, 0, 0, 0, 1
]
```

Or smaller arrays with smaller amount of leading or trailing bytes (depending on endianness):

```
[0, 0, 0, 0, 0, 0, 0, 1]
[0, 0, 0, 1]
[0, 1]
[1]
```

All these inputs produce the same hashes.

To avoid confusion, do not allow smaller inputs the modulus and make padding mandatory.